### PR TITLE
fix: BrowserRouter error

### DIFF
--- a/book-symtong/cdd-todo/.storybook/preview.tsx
+++ b/book-symtong/cdd-todo/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/react';
 
 import { BrowserRouter } from 'react-router-dom';
+import React from 'react';
 
 const preview: Preview = {
   parameters: {
@@ -18,10 +19,8 @@ export default preview;
 
 export const decorators = [
   (Story) => (
-    <ToDoListContextProvider>
-      <BrowserRouter>
-        <Story />
-      </BrowserRouter>
-    </ToDoListContextProvider>
+    <BrowserRouter>
+      <Story />
+    </BrowserRouter>
   ),
 ];


### PR DESCRIPTION
우선 파일명을 `ts`에서 `tsx`로 변경해야 합니다.

```tsx
export const decorators = [
  (Story) => (
    <BrowserRouter>
      <Story />
    </BrowserRouter>
  ),
];
```

을 보면 `JSX` 문법을 사용하고 있습니다. 하지만 `.ts` 파일은 `TypeScript`라는 의미이기에 이 파일에서는 `JSX` 문법을 이해할 수 없습니다. 그래서 `.tsx`(TypeScript JSX)로 변경하여 `TypeScript` 기반의 `JSX` 파일이라는 것을 알려 줘야 합니다.

`ToDoListContextProvider`는 아직 개발을 하지 않아기 때문에, 제거하였습니다.

이렇게 코드를 수정하면 문제가 해결될거 같습니다.